### PR TITLE
Building RPMs didn't work on develop/7 

### DIFF
--- a/SPECS/virtuoso-opensource.spec
+++ b/SPECS/virtuoso-opensource.spec
@@ -25,7 +25,7 @@ make
  
 %install
 make install DESTDIR=%{buildroot}
-mkdir -p %{buildroot}/{etc/init.d/,var/log/virtuoso,etc/logrotate.d}
+mkdir -p %{buildroot}/{etc/init.d/,var/log/virtuoso,etc/logrotate.d,etc/systemd/system}
 cp tf-addons/virtuoso.service  "%{buildroot}/etc/systemd/system/virtuoso.service"
 cp tf-addons/virtuoso.logrotate "%{buildroot}/etc/logrotate.d/virtuoso"
 sed -i 's/\/var\/lib\/virtuoso\/db\/virtuoso.log/\/var\/log\/virtuoso\/database.log/' %{buildroot}/var/lib/virtuoso/db/virtuoso.ini

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -10,8 +10,10 @@ git pull
 
 
 if [ -e "configure.ac" ]
+then
     CONFIGURE_IN="configure.ac"
 elif [ -e "configure.in" ]
+then
     CONFIGURE_IN="configure.in"
 else
     echo "Error: Could not find a suitable configure file to determine the version"

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/bin/bash -v
+ 
 ## get latest code on specified branch
 ## and extract version info
 pushd ~/virtuoso-opensource
@@ -8,16 +8,25 @@ echo "updating virtuoso branch $VIRT_BRANCH"
 git checkout $VIRT_BRANCH
 git pull
 
-VIRT_VERSION_MAJ=`grep -o -P 'vos_major,\s+\[[0-9]+\]' configure.in | grep -o -P '[0-9]+'`
-VIRT_VERSION_MIN=`grep -o -P 'vos_minor,\s+\[[0-9]+\]' configure.in | grep -o -P '[0-9]+'`
-VIRT_VERSION_PATCH=`grep -o -P 'vos_patch,\s+\[[0-9]+\]' configure.in | grep -o -P '[0-9]+'`
-VIRT_VERSION_DEV=`grep -o -P 'vos_devel,\s+\[\-[a-z0-9-]+\]\)' configure.in | grep -o -P '\-[a-z0-9]+'`
+
+if [ -e "configure.ac" ]
+    CONFIGURE_IN="configure.ac"
+elif [ -e "configure.in" ]
+    CONFIGURE_IN="configure.in"
+else
+    echo "Error: Could not find a suitable configure file to determine the version"
+    exit 1
+if
+
+VIRT_VERSION_MAJ=`grep -o -P 'vos_major,\s+\[[0-9]+\]' $CONFIGURE_IN | grep -o -P '[0-9]+'`
+VIRT_VERSION_MIN=`grep -o -P 'vos_minor,\s+\[[0-9]+\]' $CONFIGURE_IN | grep -o -P '[0-9]+'`
+VIRT_VERSION_PATCH=`grep -o -P 'vos_patch,\s+\[[0-9]+\]' $CONFIGURE_IN | grep -o -P '[0-9]+'`
+VIRT_VERSION_DEV=`grep -o -P 'vos_devel,\s+\[\-[a-z0-9-]+\]\)' $CONFIGURE_IN | grep -o -P '\-[a-z0-9]+'`
 VIRT_CUR_VERSION="$VIRT_VERSION_MAJ.$VIRT_VERSION_MIN.$VIRT_VERSION_PATCH"
 VIRT_RELEASE=`git rev-parse --short HEAD`
 VIRTUOSO_VERSION="$VIRT_CUR_VERSION.$VIRT_RELEASE"
 echo "starting rpm build of $VIRTUOSO_VERSION"
 popd
-
 
 ## add version info in the RPM spec
 VIR_DATE=`date +"%a %b %d %Y"`

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -v
+#!/bin/bash
  
 ## get latest code on specified branch
 ## and extract version info

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -18,7 +18,7 @@ then
 else
     echo "Error: Could not find a suitable configure file to determine the version"
     exit 1
-if
+fi
 
 VIRT_VERSION_MAJ=`grep -o -P 'vos_major,\s+\[[0-9]+\]' $CONFIGURE_IN | grep -o -P '[0-9]+'`
 VIRT_VERSION_MIN=`grep -o -P 'vos_minor,\s+\[[0-9]+\]' $CONFIGURE_IN | grep -o -P '[0-9]+'`


### PR DESCRIPTION
Building RPMs didn't work because the version not parsed if configure.in is not there.

SPEC file missing some paths

Possibly, changes were tested without freshly pulled repo, maybe some other changes.

Tested on CentOS 7, was able to build RPMS natively using the shell script,  with Docker, it failed when the database was started. 